### PR TITLE
Apply bug fix from master team repo

### DIFF
--- a/src/main/java/tagline/logic/commands/contact/DeleteContactCommand.java
+++ b/src/main/java/tagline/logic/commands/contact/DeleteContactCommand.java
@@ -2,15 +2,14 @@ package tagline.logic.commands.contact;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
+import java.util.Optional;
 
-import tagline.commons.core.Messages;
-import tagline.commons.core.index.Index;
 import tagline.logic.commands.CommandResult;
 import tagline.logic.commands.CommandResult.ViewType;
 import tagline.logic.commands.exceptions.CommandException;
 import tagline.model.Model;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 
 /**
  * Deletes a contact identified using it's displayed index from the address book.
@@ -26,22 +25,24 @@ public class DeleteContactCommand extends ContactCommand {
 
     public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Deleted Contact: %1$s";
 
-    private final Index targetIndex;
+    public static final String MESSAGE_NON_EXISTING_ID = "Wrong contact ID.";
 
-    public DeleteContactCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    private final ContactId contactId;
+
+    public DeleteContactCommand(ContactId contactId) {
+        this.contactId = contactId;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Contact> lastShownList = model.getFilteredContactList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        Optional<Contact> contact = model.findContact(contactId);
+        if (contact.isEmpty()) {
+            throw new CommandException(MESSAGE_NON_EXISTING_ID);
         }
 
-        Contact contactToDelete = lastShownList.get(targetIndex.getZeroBased());
+        Contact contactToDelete = contact.get();
         model.deleteContact(contactToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_CONTACT_SUCCESS, contactToDelete), ViewType.CONTACT);
     }
@@ -50,6 +51,6 @@ public class DeleteContactCommand extends ContactCommand {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteContactCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteContactCommand) other).targetIndex)); // state check
+                && contactId.equals(((DeleteContactCommand) other).contactId)); // state check
     }
 }

--- a/src/main/java/tagline/logic/commands/contact/EditContactCommand.java
+++ b/src/main/java/tagline/logic/commands/contact/EditContactCommand.java
@@ -8,11 +8,8 @@ import static tagline.logic.parser.contact.ContactCliSyntax.PREFIX_NAME;
 import static tagline.logic.parser.contact.ContactCliSyntax.PREFIX_PHONE;
 import static tagline.model.contact.ContactModel.PREDICATE_SHOW_ALL_CONTACTS;
 
-import java.util.List;
 import java.util.Optional;
 
-import tagline.commons.core.Messages;
-import tagline.commons.core.index.Index;
 import tagline.commons.util.CollectionUtil;
 import tagline.logic.commands.CommandResult;
 import tagline.logic.commands.CommandResult.ViewType;
@@ -20,6 +17,7 @@ import tagline.logic.commands.exceptions.CommandException;
 import tagline.model.Model;
 import tagline.model.contact.Address;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.Description;
 import tagline.model.contact.Email;
 import tagline.model.contact.Name;
@@ -50,18 +48,20 @@ public class EditContactCommand extends ContactCommand {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in the address book.";
 
-    private final Index index;
+    public static final String MESSAGE_NON_EXISTING_ID = "Wrong contact ID.";
+
+    private final ContactId contactId;
     private final EditContactDescriptor editContactDescriptor;
 
     /**
-     * @param index                 of the contact in the filtered contact list to edit
+     * @param contactId             of the contact to be edited
      * @param editContactDescriptor details to edit the contact with
      */
-    public EditContactCommand(Index index, EditContactDescriptor editContactDescriptor) {
-        requireNonNull(index);
+    public EditContactCommand(ContactId contactId, EditContactDescriptor editContactDescriptor) {
+        requireNonNull(contactId);
         requireNonNull(editContactDescriptor);
 
-        this.index = index;
+        this.contactId = contactId;
         this.editContactDescriptor = new EditContactDescriptor(editContactDescriptor);
     }
 
@@ -78,19 +78,20 @@ public class EditContactCommand extends ContactCommand {
         Address updatedAddress = editContactDescriptor.getAddress().orElse(contactToEdit.getAddress());
         Description updatedDescription = editContactDescriptor.getDescription().orElse(contactToEdit.getDescription());
 
-        return new Contact(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedDescription);
+        return new Contact(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedDescription,
+                contactToEdit.getContactId());
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Contact> lastShownList = model.getFilteredContactList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        Optional<Contact> contact = model.findContact(contactId);
+        if (contact.isEmpty()) {
+            throw new CommandException(MESSAGE_NON_EXISTING_ID);
         }
 
-        Contact contactToEdit = lastShownList.get(index.getZeroBased());
+        Contact contactToEdit = contact.get();
         Contact editedContact = createEditedContact(contactToEdit, editContactDescriptor);
 
         if (!contactToEdit.isSameContact(editedContact) && model.hasContact(editedContact)) {
@@ -116,7 +117,7 @@ public class EditContactCommand extends ContactCommand {
 
         // state check
         EditContactCommand e = (EditContactCommand) other;
-        return index.equals(e.index)
+        return contactId.equals(e.contactId)
                 && editContactDescriptor.equals(e.editContactDescriptor);
     }
 
@@ -130,6 +131,7 @@ public class EditContactCommand extends ContactCommand {
         private Email email;
         private Address address;
         private Description description;
+        private ContactId contactId;
 
         public EditContactDescriptor() {
         }
@@ -144,6 +146,7 @@ public class EditContactCommand extends ContactCommand {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setDescription(toCopy.description);
+            setContactId(toCopy.contactId);
         }
 
         /**
@@ -191,6 +194,14 @@ public class EditContactCommand extends ContactCommand {
 
         public void setDescription(Description description) {
             this.description = description;
+        }
+
+        public Optional<ContactId> getContactId() {
+            return Optional.ofNullable(contactId);
+        }
+
+        public void setContactId(ContactId contactId) {
+            this.contactId = contactId;
         }
 
         @Override

--- a/src/main/java/tagline/logic/parser/contact/ContactParserUtil.java
+++ b/src/main/java/tagline/logic/parser/contact/ContactParserUtil.java
@@ -6,6 +6,7 @@ import tagline.commons.core.index.Index;
 import tagline.commons.util.StringUtil;
 import tagline.logic.parser.exceptions.ParseException;
 import tagline.model.contact.Address;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.Description;
 import tagline.model.contact.Email;
 import tagline.model.contact.Name;
@@ -21,6 +22,7 @@ public class ContactParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -29,6 +31,20 @@ public class ContactParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code id} into an {@code ContactId} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     *
+     * @throws ParseException if the specified id is invalid.
+     */
+    public static ContactId parseContactId(String id) throws ParseException {
+        String trimmedId = id.trim();
+        if (!ContactId.isValidId(trimmedId)) {
+            throw new ParseException((ContactId.MESSAGE_CONSTRAINTS));
+        }
+        return new ContactId(trimmedId);
     }
 
     /**

--- a/src/main/java/tagline/logic/parser/contact/DeleteContactParser.java
+++ b/src/main/java/tagline/logic/parser/contact/DeleteContactParser.java
@@ -2,10 +2,10 @@ package tagline.logic.parser.contact;
 
 import static tagline.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import tagline.commons.core.index.Index;
 import tagline.logic.commands.contact.DeleteContactCommand;
 import tagline.logic.parser.Parser;
 import tagline.logic.parser.exceptions.ParseException;
+import tagline.model.contact.ContactId;
 
 /**
  * Parses input arguments and creates a new DeleteContactCommand object
@@ -15,12 +15,13 @@ public class DeleteContactParser implements Parser<DeleteContactCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteContactCommand
      * and returns a DeleteContactCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteContactCommand parse(String args) throws ParseException {
         try {
-            Index index = ContactParserUtil.parseIndex(args);
-            return new DeleteContactCommand(index);
+            ContactId contactId = ContactParserUtil.parseContactId(args);
+            return new DeleteContactCommand(contactId);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteContactCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/tagline/logic/parser/contact/EditCommandParser.java
+++ b/src/main/java/tagline/logic/parser/contact/EditCommandParser.java
@@ -8,13 +8,13 @@ import static tagline.logic.parser.contact.ContactCliSyntax.PREFIX_EMAIL;
 import static tagline.logic.parser.contact.ContactCliSyntax.PREFIX_NAME;
 import static tagline.logic.parser.contact.ContactCliSyntax.PREFIX_PHONE;
 
-import tagline.commons.core.index.Index;
 import tagline.logic.commands.contact.EditContactCommand;
 import tagline.logic.commands.contact.EditContactCommand.EditContactDescriptor;
 import tagline.logic.parser.ArgumentMultimap;
 import tagline.logic.parser.ArgumentTokenizer;
 import tagline.logic.parser.Parser;
 import tagline.logic.parser.exceptions.ParseException;
+import tagline.model.contact.ContactId;
 
 /**
  * Parses input arguments and creates a new EditContactCommand object
@@ -33,10 +33,10 @@ public class EditCommandParser implements Parser<EditContactCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_DESCRIPTION);
 
-        Index index;
+        ContactId contactId;
 
         try {
-            index = ContactParserUtil.parseIndex(argMultimap.getPreamble());
+            contactId = ContactParserUtil.parseContactId(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditContactCommand.MESSAGE_USAGE), pe);
@@ -69,6 +69,6 @@ public class EditCommandParser implements Parser<EditContactCommand> {
             throw new ParseException(EditContactCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditContactCommand(index, editContactDescriptor);
+        return new EditContactCommand(contactId, editContactDescriptor);
     }
 }

--- a/src/main/java/tagline/model/Model.java
+++ b/src/main/java/tagline/model/Model.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import tagline.commons.core.GuiSettings;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.ReadOnlyAddressBook;
 import tagline.model.note.Note;
 import tagline.model.note.ReadOnlyNoteBook;
@@ -83,7 +84,7 @@ public interface Model {
     /**
      * Finds a contact with given {@code id} if it exists in the address book.
      */
-    Optional<Contact> findContact(int id);
+    Optional<Contact> findContact(ContactId id);
 
     /**
      * Returns an unmodifiable view of the filtered contact list

--- a/src/main/java/tagline/model/ModelManager.java
+++ b/src/main/java/tagline/model/ModelManager.java
@@ -13,6 +13,7 @@ import tagline.commons.core.GuiSettings;
 import tagline.commons.core.LogsCenter;
 import tagline.model.contact.AddressBook;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.ContactManager;
 import tagline.model.contact.ReadOnlyAddressBook;
 import tagline.model.note.Note;
@@ -127,7 +128,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Optional<Contact> findContact(int id) {
+    public Optional<Contact> findContact(ContactId id) {
         return contactManager.findContact(id);
     }
 

--- a/src/main/java/tagline/model/contact/AddressBook.java
+++ b/src/main/java/tagline/model/contact/AddressBook.java
@@ -84,7 +84,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setContact(Contact target, Contact editedContact) {
         requireNonNull(editedContact);
-
+        assert (target.getContactId().equals(editedContact.getContactId()))
+                : "Contact id is permanent and cannot be edited";
         contacts.setContact(target, editedContact);
     }
 
@@ -94,10 +95,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeContact(Contact key) {
         contacts.remove(key);
-    }
-
-    public Optional<Contact> findContact(int id) {
-        return contacts.findContact(id);
     }
 
     public Optional<Contact> findContact(ContactId contactId) {

--- a/src/main/java/tagline/model/contact/Contact.java
+++ b/src/main/java/tagline/model/contact/Contact.java
@@ -35,7 +35,6 @@ public class Contact {
     /**
      * Construct a contact with id.
      * Ensure that the id is unique among all other contact.
-     * Warning: This constructor should only be used by storage.
      */
     public Contact(Name name, Phone phone, Email email, Address address, Description description, ContactId contactId) {
         requireAllNonNull(name, phone, email, address, description);

--- a/src/main/java/tagline/model/contact/ContactId.java
+++ b/src/main/java/tagline/model/contact/ContactId.java
@@ -14,19 +14,23 @@ public class ContactId {
     private final int id;
 
     /**
-     * Constructs a contact Id from a String.
-     * Warning: This constructor should only be used by storage.
+     * Construct a contact Id from String.
+     *
+     * @param id
      */
     public ContactId(String id) {
-        this.id = Integer.valueOf(id);
+        this(Integer.valueOf(id));
     }
 
     /**
      * Constructs a contact Id from an integer.
      */
-    ContactId(int id) {
+    public ContactId(int id) {
         if (id >= Math.pow(10, contactIdDigits)) {
             throw new InvalidIdException("Id too large");
+        }
+        if (id < 0) {
+            throw new InvalidIdException("Id has to be a positive number");
         }
         this.id = id;
     }
@@ -79,16 +83,11 @@ public class ContactId {
             return true;
         }
 
-        int other;
-        if (obj instanceof Integer) {
-            other = (Integer) obj;
-        } else if (obj instanceof ContactId) {
-            other = ((ContactId) obj).id;
-        } else {
+        if (!(obj instanceof ContactId)) {
             return false;
         }
 
-        return id == other;
+        return id == ((ContactId) obj).id;
     }
 
     @Override

--- a/src/main/java/tagline/model/contact/ContactManager.java
+++ b/src/main/java/tagline/model/contact/ContactManager.java
@@ -60,7 +60,7 @@ public class ContactManager implements ContactModel {
     }
 
     @Override
-    public Optional<Contact> findContact(int id) {
+    public Optional<Contact> findContact(ContactId id) {
         return addressBook.findContact(id);
     }
 
@@ -77,7 +77,7 @@ public class ContactManager implements ContactModel {
 
         int limit = (int) Math.pow(10, ContactId.getDigit());
         int randomId = ThreadLocalRandom.current().nextInt(limit);
-        while (findContact(randomId).isPresent()) {
+        while (findContact(new ContactId(randomId)).isPresent()) {
             randomId = ThreadLocalRandom.current().nextInt(limit);
         }
 

--- a/src/main/java/tagline/model/contact/ContactModel.java
+++ b/src/main/java/tagline/model/contact/ContactModel.java
@@ -49,7 +49,7 @@ public interface ContactModel {
      */
     void setContact(Contact target, Contact editedContact);
 
-    Optional<Contact> findContact(int id);
+    Optional<Contact> findContact(ContactId id);
 
     /**
      * Returns an unmodifiable view of the filtered contact list

--- a/src/main/java/tagline/model/contact/UniqueContactList.java
+++ b/src/main/java/tagline/model/contact/UniqueContactList.java
@@ -45,7 +45,7 @@ public class UniqueContactList implements Iterable<Contact> {
      * @param id of the contact
      * @return an optional object which implies whether the corresponding contact is found or not.
      */
-    public Optional<Contact> findContact(int id) {
+    public Optional<Contact> findContact(ContactId id) {
         var it = iterator();
         while (it.hasNext()) {
             Contact currentContact = it.next();
@@ -54,10 +54,6 @@ public class UniqueContactList implements Iterable<Contact> {
             }
         }
         return Optional.empty();
-    }
-
-    public Optional<Contact> findContact(ContactId contactId) {
-        return findContact(contactId.toInteger());
     }
 
     public int size() {

--- a/src/test/java/tagline/logic/LogicManagerTest.java
+++ b/src/test/java/tagline/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package tagline.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static tagline.commons.core.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static tagline.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static tagline.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tagline.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import tagline.logic.commands.CommandResult;
 import tagline.logic.commands.contact.ContactCommand;
 import tagline.logic.commands.contact.CreateContactCommand;
+import tagline.logic.commands.contact.DeleteContactCommand;
 import tagline.logic.commands.contact.ListContactCommand;
 import tagline.logic.commands.exceptions.CommandException;
 import tagline.logic.parser.exceptions.ParseException;
@@ -62,8 +62,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "contact delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        String deleteCommand = "contact delete 99999";
+        assertCommandException(deleteCommand, DeleteContactCommand.MESSAGE_NON_EXISTING_ID);
     }
 
     @Test

--- a/src/test/java/tagline/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tagline/logic/commands/CommandTestUtil.java
@@ -19,6 +19,7 @@ import tagline.logic.commands.exceptions.CommandException;
 import tagline.model.Model;
 import tagline.model.contact.AddressBook;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.NameContainsKeywordsPredicate;
 import tagline.testutil.EditContactDescriptorBuilder;
 
@@ -56,6 +57,10 @@ public class CommandTestUtil {
 
     public static final EditContactCommand.EditContactDescriptor DESC_AMY;
     public static final EditContactCommand.EditContactDescriptor DESC_BOB;
+
+    public static final ContactId NON_EXISTING_ID = new ContactId(99999);
+    public static final ContactId CONTACT_ID_ONE = new ContactId(1);
+    public static final ContactId CONTACT_ID_TWO = new ContactId(2);
 
     static {
         DESC_AMY = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/tagline/logic/commands/CreateContactCommandTest.java
+++ b/src/test/java/tagline/logic/commands/CreateContactCommandTest.java
@@ -23,6 +23,7 @@ import tagline.model.ReadOnlyUserPrefs;
 import tagline.model.contact.AddressBook;
 import tagline.model.contact.Contact;
 import tagline.model.contact.ContactBuilder;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.ReadOnlyAddressBook;
 import tagline.model.note.Note;
 import tagline.model.note.ReadOnlyNoteBook;
@@ -155,7 +156,7 @@ public class CreateContactCommandTest {
         }
 
         @Override
-        public Optional<Contact> findContact(int id) {
+        public Optional<Contact> findContact(ContactId id) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/tagline/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/tagline/logic/commands/EditContactCommandTest.java
@@ -4,19 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tagline.logic.commands.CommandTestUtil.DESC_AMY;
 import static tagline.logic.commands.CommandTestUtil.DESC_BOB;
+import static tagline.logic.commands.CommandTestUtil.NON_EXISTING_ID;
 import static tagline.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tagline.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tagline.logic.commands.CommandTestUtil.assertCommandFailure;
 import static tagline.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static tagline.logic.commands.CommandTestUtil.showContactAtIndex;
 import static tagline.testutil.TypicalContacts.getTypicalAddressBook;
 import static tagline.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 import static tagline.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
 
 import org.junit.jupiter.api.Test;
 
-import tagline.commons.core.Messages;
-import tagline.commons.core.index.Index;
 import tagline.logic.commands.CommandResult.ViewType;
 import tagline.logic.commands.contact.ClearContactCommand;
 import tagline.logic.commands.contact.EditContactCommand;
@@ -27,6 +25,7 @@ import tagline.model.UserPrefs;
 import tagline.model.contact.AddressBook;
 import tagline.model.contact.Contact;
 import tagline.model.contact.ContactBuilder;
+import tagline.model.contact.ContactId;
 import tagline.model.note.NoteBook;
 import tagline.testutil.EditContactDescriptorBuilder;
 
@@ -40,10 +39,12 @@ public class EditContactCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new NoteBook(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Contact editedContact = new ContactBuilder().build();
+    public void execute_allFieldsSpecified_success() {
+        Contact originalContact = model.getAddressBook().getContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact editedContact = new ContactBuilder().withId(originalContact.getContactId().toInteger()).build();
+
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
-        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_CONTACT, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(originalContact.getContactId(), descriptor);
 
         String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_CONTACT_SUCCESS, editedContact);
 
@@ -55,9 +56,10 @@ public class EditContactCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastContact = Index.fromOneBased(model.getFilteredContactList().size());
-        Contact lastContact = model.getFilteredContactList().get(indexLastContact.getZeroBased());
+    public void execute_someFieldsSpecified_success() {
+        var contactList = model.getAddressBook().getContactList();
+        int contactListSize = contactList.size();
+        Contact lastContact = contactList.get(contactListSize - 1);
 
         ContactBuilder contactInList = new ContactBuilder(lastContact);
         Contact editedContact = contactInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -65,7 +67,7 @@ public class EditContactCommandTest {
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).build();
-        EditContactCommand editContactCommand = new EditContactCommand(indexLastContact, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(lastContact.getContactId(), descriptor);
 
         String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_CONTACT_SUCCESS, editedContact);
 
@@ -77,10 +79,10 @@ public class EditContactCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditContactCommand editContactCommand =
-                new EditContactCommand(INDEX_FIRST_CONTACT, new EditContactDescriptor());
+    public void execute_noFieldSpecified_success() {
         Contact editedContact = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        EditContactCommand editContactCommand =
+                new EditContactCommand(editedContact.getContactId(), new EditContactDescriptor());
 
         String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_CONTACT_SUCCESS, editedContact);
 
@@ -91,77 +93,34 @@ public class EditContactCommandTest {
     }
 
     @Test
-    public void execute_filteredList_success() {
-        showContactAtIndex(model, INDEX_FIRST_CONTACT);
+    public void execute_duplicateContact_failure() {
+        var contactList = model.getAddressBook().getContactList();
+        Contact firstContact = contactList.get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact secondContact = contactList.get(INDEX_SECOND_CONTACT.getZeroBased());
 
-        Contact contactInFilteredList = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
-        Contact editedContact = new ContactBuilder(contactInFilteredList).withName(VALID_NAME_BOB).build();
-        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_CONTACT,
-                new EditContactDescriptorBuilder().withName(VALID_NAME_BOB).build());
-
-        String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_CONTACT_SUCCESS, editedContact);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new NoteBook(), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList().get(0), editedContact);
-
-        assertCommandSuccess(editContactCommand, model, expectedMessage, EDIT_CONTACT_COMMAND_VIEW_TYPE, expectedModel);
-    }
-
-    @Test
-    public void execute_duplicateContactUnfilteredList_failure() {
-        Contact firstContact = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(firstContact).build();
-        EditContactCommand editContactCommand = new EditContactCommand(INDEX_SECOND_CONTACT, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(secondContact.getContactId(), descriptor);
 
         assertCommandFailure(editContactCommand, model, EditContactCommand.MESSAGE_DUPLICATE_CONTACT);
     }
 
     @Test
-    public void execute_duplicateContactFilteredList_failure() {
-        showContactAtIndex(model, INDEX_FIRST_CONTACT);
+    public void execute_invalidContactIdUnfilteredList_failure() {
+        ContactId nonExistingId = NON_EXISTING_ID;
 
-        // edit contact in filtered list into a duplicate in address book
-        Contact contactInList = model.getAddressBook().getContactList().get(INDEX_SECOND_CONTACT.getZeroBased());
-        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_CONTACT,
-                new EditContactDescriptorBuilder(contactInList).build());
-
-        assertCommandFailure(editContactCommand, model, EditContactCommand.MESSAGE_DUPLICATE_CONTACT);
-    }
-
-    @Test
-    public void execute_invalidContactIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditContactCommand editContactCommand = new EditContactCommand(outOfBoundIndex, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(nonExistingId, descriptor);
 
-        assertCommandFailure(editContactCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
-    }
-
-    /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of address book
-     */
-    @Test
-    public void execute_invalidContactIndexFilteredList_failure() {
-        showContactAtIndex(model, INDEX_FIRST_CONTACT);
-        Index outOfBoundIndex = INDEX_SECOND_CONTACT;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getContactList().size());
-
-        EditContactCommand editContactCommand = new EditContactCommand(outOfBoundIndex,
-                new EditContactDescriptorBuilder().withName(VALID_NAME_BOB).build());
-
-        assertCommandFailure(editContactCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(editContactCommand, model, EditContactCommand.MESSAGE_NON_EXISTING_ID);
     }
 
     @Test
     public void equals() {
-        final EditContactCommand standardCommand = new EditContactCommand(INDEX_FIRST_CONTACT, DESC_AMY);
+        final EditContactCommand standardCommand = new EditContactCommand(new ContactId(1), DESC_AMY);
 
         // same values -> returns true
         EditContactDescriptor copyDescriptor = new EditContactDescriptor(DESC_AMY);
-        EditContactCommand commandWithSameValues = new EditContactCommand(INDEX_FIRST_CONTACT, copyDescriptor);
+        EditContactCommand commandWithSameValues = new EditContactCommand(new ContactId(1), copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -174,10 +133,9 @@ public class EditContactCommandTest {
         assertFalse(standardCommand.equals(new ClearContactCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditContactCommand(INDEX_SECOND_CONTACT, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditContactCommand(new ContactId(2), DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditContactCommand(INDEX_FIRST_CONTACT, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditContactCommand(new ContactId(1), DESC_BOB)));
     }
-
 }

--- a/src/test/java/tagline/logic/commands/note/CreateNoteCommandTest.java
+++ b/src/test/java/tagline/logic/commands/note/CreateNoteCommandTest.java
@@ -17,6 +17,7 @@ import tagline.commons.core.GuiSettings;
 import tagline.model.Model;
 import tagline.model.ReadOnlyUserPrefs;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.ReadOnlyAddressBook;
 import tagline.model.note.Note;
 import tagline.model.note.NoteModel;
@@ -242,7 +243,7 @@ class CreateNoteCommandTest {
         }
 
         @Override
-        public Optional<Contact> findContact(int id) {
+        public Optional<Contact> findContact(ContactId id) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/tagline/logic/parser/ContactCommandParserTest.java
+++ b/src/test/java/tagline/logic/parser/ContactCommandParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tagline.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static tagline.testutil.Assert.assertThrows;
-import static tagline.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +22,7 @@ import tagline.logic.parser.contact.ContactCommandParser;
 import tagline.logic.parser.exceptions.ParseException;
 import tagline.model.contact.Contact;
 import tagline.model.contact.ContactBuilder;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.NameContainsKeywordsPredicate;
 import tagline.testutil.ContactUtil;
 import tagline.testutil.EditContactDescriptorBuilder;
@@ -46,9 +46,10 @@ public class ContactCommandParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
+        ContactId contactId = new ContactId(1);
         DeleteContactCommand command = (DeleteContactCommand) parser.parseCommand(
-                DeleteContactCommand.COMMAND_WORD + " " + INDEX_FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteContactCommand(INDEX_FIRST_CONTACT), command);
+                DeleteContactCommand.COMMAND_WORD + " " + contactId.toString());
+        assertEquals(new DeleteContactCommand(contactId), command);
     }
 
     @Test
@@ -56,8 +57,8 @@ public class ContactCommandParserTest {
         Contact contact = new ContactBuilder().build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(contact).build();
         EditContactCommand command = (EditContactCommand) parser.parseCommand(EditContactCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_CONTACT.getOneBased() + " " + ContactUtil.getEditContactDescriptorDetails(descriptor));
-        assertEquals(new EditContactCommand(INDEX_FIRST_CONTACT, descriptor), command);
+                + contact.getContactId().toString() + " " + ContactUtil.getEditContactDescriptorDetails(descriptor));
+        assertEquals(new EditContactCommand(contact.getContactId(), descriptor), command);
     }
 
     @Test

--- a/src/test/java/tagline/logic/parser/DeleteContactParserTest.java
+++ b/src/test/java/tagline/logic/parser/DeleteContactParserTest.java
@@ -3,12 +3,12 @@ package tagline.logic.parser;
 import static tagline.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tagline.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static tagline.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static tagline.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 
 import org.junit.jupiter.api.Test;
 
 import tagline.logic.commands.contact.DeleteContactCommand;
 import tagline.logic.parser.contact.DeleteContactParser;
+import tagline.model.contact.ContactId;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -23,12 +23,18 @@ public class DeleteContactParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteContactCommand(INDEX_FIRST_CONTACT));
+        assertParseSuccess(parser, "1", new DeleteContactCommand(new ContactId(1)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteContactCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteContactCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "10a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteContactCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/tagline/logic/parser/EditContactCommandParserTest.java
+++ b/src/test/java/tagline/logic/parser/EditContactCommandParserTest.java
@@ -3,6 +3,7 @@ package tagline.logic.parser;
 import static tagline.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tagline.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tagline.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static tagline.logic.commands.CommandTestUtil.CONTACT_ID_ONE;
 import static tagline.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static tagline.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static tagline.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -20,16 +21,13 @@ import static tagline.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static tagline.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tagline.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static tagline.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static tagline.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
-import static tagline.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
-import static tagline.testutil.TypicalIndexes.INDEX_THIRD_CONTACT;
 
 import org.junit.jupiter.api.Test;
 
-import tagline.commons.core.index.Index;
 import tagline.logic.commands.contact.EditContactCommand;
 import tagline.logic.commands.contact.EditContactCommand.EditContactDescriptor;
 import tagline.logic.parser.contact.EditCommandParser;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.Email;
 import tagline.model.contact.Name;
 import tagline.model.contact.Phone;
@@ -56,11 +54,8 @@ public class EditContactCommandParserTest {
 
     @Test
     public void parse_invalidPreamble_failure() {
-        // negative index
+        // negative id
         assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
-        // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
@@ -89,26 +84,27 @@ public class EditContactCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_CONTACT;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB
+        ContactId targetContactId = CONTACT_ID_ONE;
+
+        String userInput = targetContactId.toString() + PHONE_DESC_BOB
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .build();
-        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
+                .withContactId(CONTACT_ID_ONE).build();
+        EditContactCommand expectedCommand = new EditContactCommand(targetContactId, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_CONTACT;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        ContactId targetContactId = CONTACT_ID_ONE;
+        String userInput = targetContactId.toString() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetContactId, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -116,42 +112,42 @@ public class EditContactCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_CONTACT;
-        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
+        ContactId targetContactId = CONTACT_ID_ONE;
+        String userInput = targetContactId.toString() + NAME_DESC_AMY;
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
+        userInput = targetContactId.toString() + PHONE_DESC_AMY;
         descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
+        userInput = targetContactId.toString() + EMAIL_DESC_AMY;
         descriptor = new EditContactDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
-        userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
+        userInput = targetContactId.toString() + ADDRESS_DESC_AMY;
         descriptor = new EditContactDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_CONTACT;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+        ContactId targetContactId = CONTACT_ID_ONE;
+        String userInput = targetContactId.toString() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .build();
-        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetContactId, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -159,18 +155,18 @@ public class EditContactCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_CONTACT;
-        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        ContactId targetContactId = CONTACT_ID_ONE;
+        String userInput = targetContactId.toString() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
-        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
+        userInput = targetContactId.toString() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
                 + PHONE_DESC_BOB;
         descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
-        expectedCommand = new EditContactCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetContactId, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/tagline/model/contact/AddressBookTest.java
+++ b/src/test/java/tagline/model/contact/AddressBookTest.java
@@ -80,6 +80,29 @@ public class AddressBookTest {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getContactList().remove(0));
     }
 
+    @Test
+    public void addContact_contactWithNullId_throwsNullPointerException() {
+        Contact contact = (new ContactBuilder()).build();
+        contact.setContactId(null);
+
+        assertThrows(NullPointerException.class, () -> addressBook.addContact(contact));
+    }
+
+    @Test
+    public void addContact_contactWithDuplicateId_throwsAssertionError() {
+        addressBook.addContact(ALICE);
+        Contact contact = (new ContactBuilder()).withId(ALICE.getContactId().toInteger()).build();
+
+        assertThrows(AssertionError.class, () -> addressBook.addContact(contact));
+    }
+
+    @Test
+    public void editContact_editContactId_throwsAssertionError() {
+        addressBook.addContact(ALICE);
+        Contact newAlice = (new ContactBuilder(ALICE)).withId(ALICE.getContactId().toInteger() + 1).build();
+        assertThrows(AssertionError.class, () -> addressBook.setContact(ALICE, newAlice));
+    }
+
     /**
      * A stub ReadOnlyAddressBook whose contacts list can violate interface constraints.
      */

--- a/src/test/java/tagline/model/contact/ContactIdTest.java
+++ b/src/test/java/tagline/model/contact/ContactIdTest.java
@@ -1,0 +1,38 @@
+package tagline.model.contact;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tagline.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import tagline.model.contact.exceptions.InvalidIdException;
+
+public class ContactIdTest {
+    @Test
+    public void constructor_nonIntegerString_throwsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> new ContactId("a"));
+        assertThrows(NumberFormatException.class, () -> new ContactId("1a"));
+    }
+
+    @Test
+    public void constructor_invalidId_throwsInvalidIdException() {
+        int tooBigId = (int) Math.pow(10, ContactId.getDigit());
+        assertThrows(InvalidIdException.class, () -> new ContactId(tooBigId));
+
+        int negativeId = -1;
+        assertThrows(InvalidIdException.class, () -> new ContactId(negativeId));
+    }
+
+    @Test
+    public void isValidId() {
+        // invalid id
+        assertFalse(ContactId.isValidId("")); // empty string
+        assertFalse(ContactId.isValidId("a")); // non-integer string
+        assertFalse(ContactId.isValidId("1a1")); // non-integer string
+
+        // valid id
+        assertTrue(ContactId.isValidId("1")); // integer string
+        assertTrue(ContactId.isValidId("0000000000000001")); // integer string with leading zeros
+    }
+}

--- a/src/test/java/tagline/testutil/EditContactDescriptorBuilder.java
+++ b/src/test/java/tagline/testutil/EditContactDescriptorBuilder.java
@@ -3,6 +3,7 @@ package tagline.testutil;
 import tagline.logic.commands.contact.EditContactCommand.EditContactDescriptor;
 import tagline.model.contact.Address;
 import tagline.model.contact.Contact;
+import tagline.model.contact.ContactId;
 import tagline.model.contact.Email;
 import tagline.model.contact.Name;
 import tagline.model.contact.Phone;
@@ -32,6 +33,7 @@ public class EditContactDescriptorBuilder {
         descriptor.setEmail(contact.getEmail());
         descriptor.setAddress(contact.getAddress());
         descriptor.setDescription(contact.getDescription());
+        descriptor.setContactId(contact.getContactId());
     }
 
     /**
@@ -63,6 +65,14 @@ public class EditContactDescriptorBuilder {
      */
     public EditContactDescriptorBuilder withAddress(String address) {
         descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ContactId} of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withContactId(ContactId id) {
+        descriptor.setContactId(id);
         return this;
     }
 


### PR DESCRIPTION
* Consistently use ContactId entity instead of integer Id

* Update EditCommand with ContactId

* Justify EditContactCommandDescriptor with ContactId

* Justify EditContactCommandTest

* Justify EditContactCommandParserTest

* Justify ContactCommandParserTest

* Minor renaming

* Change index to contactId in Delete Command

* Change NON_EXISTING_ID into a ContactId Object

* Justify DeleteContactCommandTest

* Justify DeleteContactParserTest

* Add ContactId Test

* Add validation on edit command to not change id

* Add addressBook test case which verifies unique constraint on ContactId

* Satisfy checkstyle requirement